### PR TITLE
Update catalogue URL to use raspberrypi.com

### DIFF
--- a/src/rp_bookshelf.c
+++ b/src/rp_bookshelf.c
@@ -62,7 +62,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define WIREFRAME_URL   "https://store.rpipress.cc/collections/wireframe"
 #define CUSTOMPC_URL    "https://store.rpipress.cc/collections/custom-pc-magazine"
 
-#define CATALOGUE_URL   "https://magpi.raspberrypi.org/bookshelf.xml"
+#define CATALOGUE_URL   "https://magpi.raspberrypi.com/bookshelf.xml"
 #define CACHE_PATH      "/.cache/bookshelf/"
 #define PDF_PATH        "/Bookshelf/"
 


### PR DESCRIPTION
As the magazine sites have moved from raspberrypi.org to raspberrypi.com, update the URL used to fetch the catalogue of issues and books.

Note the old raspberrypi.org URL will continue to work indefinitely due to existing clients but it's better to be consistent for new versions.
